### PR TITLE
Make expand_values_on_load eval-free

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,14 @@ Use the existing helpers (`private_flex_ini_set`, and the patterns in
 expressions. There are regression tests that feed `$(...)`, backticks, quotes,
 and globs through every path — they must stay literal.
 
-The one deliberate exception: when `expand_values_on_load=true` (default
-`false`), values containing `$` are eval-expanded on load. That is a documented
-opt-in footgun; do not widen it.
+When `expand_values_on_load=true` (default `false`), values containing `$`
+have their variable references (`$VAR`/`${VAR}`) expanded on load by
+`private_flex_ini_expand_value`. That helper uses plain bash parameter
+expansion (indirect `${!name}`) and deliberately **never** `eval`s the value:
+command substitution (`$(...)`, backticks) and every other shell construct are
+left as literal text and cannot execute. Do not "simplify" this back into
+`eval "value=\"$value\""` — that reintroduces a command-injection sink
+(CWE-78/CWE-95) on any untrusted ini file.
 
 Two related rules when a *caller-supplied name* (not a key/value) must be
 interpolated into an eval expression, as in `flex_ini_update_bulk`'s

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ back_up_changes_on_save_as=false
 ### Expand values on load
 
 By default, values are loaded exactly as they appear in the ini file — a value like `$HOME` stays the literal string `$HOME`.
-If you enable this setting, values containing `$` are run through the shell on load so variable references get expanded.
-Only enable this for ini files you fully trust: expansion uses `eval`, so a malicious value like `$(some command)` would be executed by your script.
+If you enable this setting, shell variable references (`$VAR` and `${VAR}`) in values are expanded from the current environment on load.
+Expansion is done with plain bash parameter expansion and never `eval`, so command substitutions (`$(some command)` and backticks) are left as literal text and are never executed — only variable references are substituted. Undefined variables expand to an empty string.
 
 ```
 expand_values_on_load=false

--- a/flex_ini.sh
+++ b/flex_ini.sh
@@ -21,10 +21,11 @@ auto_save_on_changes=false
 back_up_changes_on_save=true
 back_up_changes_on_save_as=false
 reassign_file_permissions_when_possible=false
-# When true, values containing '$' are run through the shell on load so
-# variable references get expanded. Leave this off unless you fully trust
-# every ini file you load: expansion uses eval, so a value like
-# "$(some command)" would be executed.
+# When true, shell variable references ($VAR and ${VAR}) in values are
+# expanded on load from the current environment. Expansion is done with
+# plain bash parameter expansion, never eval, so command substitution and
+# backticks (e.g. "$(some command)" or `some command`) are left as literal
+# text and can never be executed. Undefined variables expand to nothing.
 expand_values_on_load=false
 tmp_directory="/tmp"
 # Detect the operating system
@@ -192,6 +193,37 @@ private_flex_ini_create() {
   private_flex_ini_required "ini_file" "$ini_file" || return 1
   touch "$ini_file" || return 1
 }
+# @private private_flex_ini_expand_value
+# --
+# Expand shell variable references ($VAR and ${VAR}) in a value using the
+# current environment. This deliberately does NOT use eval or command
+# substitution: command substitutions ($(...) and backticks) and every
+# other shell construct are left untouched as literal text, so a value
+# from an untrusted ini file can never be executed as code. Undefined
+# variables expand to the empty string, matching normal shell behavior.
+# The expanded value is written to the global _flexini_expanded.
+private_flex_ini_expand_value() {
+  local _value="$1"
+  local _out=""
+  local _rest="$_value"
+  # Only referenced variable NAMES are ever substituted; the value's own
+  # characters are never re-parsed by the shell.
+  local _re='^([^$]*)[$]([{]([a-zA-Z_][a-zA-Z0-9_]*)[}]|([a-zA-Z_][a-zA-Z0-9_]*))(.*)$'
+  while [[ $_rest =~ $_re ]]; do
+    local _prefix="${BASH_REMATCH[1]}"
+    local _braced_name="${BASH_REMATCH[3]}"
+    local _bare_name="${BASH_REMATCH[4]}"
+    local _tail="${BASH_REMATCH[5]}"
+    local _name="${_braced_name:-$_bare_name}"
+    # Indirect expansion by name only -- the referenced variable's own
+    # contents are never interpreted, only substituted in as data.
+    _out+="${_prefix}${!_name-}"
+    _rest="$_tail"
+  done
+  # A bare '$' not forming a valid reference (and any trailing text) is
+  # kept verbatim.
+  _flexini_expanded="${_out}${_rest}"
+}
 # @private private_flex_ini_set
 # --
 # Assign a value to a key inside the named associative array.
@@ -319,7 +351,11 @@ flex_ini_load() {
       # trim trailing whitespace from the value
       value="${value%"${value##*[![:space:]]}"}"
       if [ "$expand_values_on_load" == "true" ] && [[ $value == *\$* ]]; then
-        eval "value=\"$value\""
+        # Safe, eval-free variable expansion: command substitution and
+        # backticks are left as literal text (see the helper).
+        local _flexini_expanded=""
+        private_flex_ini_expand_value "$value"
+        value="$_flexini_expanded"
       fi
       private_flex_ini_set "$ini" "${section}${key}" "$value"
     fi

--- a/tests/load.bats
+++ b/tests/load.bats
@@ -82,13 +82,56 @@ EOF
 @test "load expands variables when expand_values_on_load is enabled" {
   local f
   f=$(create_ini)
-  export FLEXINI_TEST_VAR="expanded"
-  printf 'var = $FLEXINI_TEST_VAR\n' >"$f"
+  FLEXINI_TEST_VAR="expanded"
+  printf 'var = $FLEXINI_TEST_VAR\nbraced = ${FLEXINI_TEST_VAR}\n' >"$f"
 
   expand_values_on_load=true
   flex_ini_load "$f"
 
   [ "$(flex_ini_get var)" = "expanded" ]
+  [ "$(flex_ini_get braced)" = "expanded" ]
+}
+
+@test "expand_values_on_load expands variables embedded in surrounding text" {
+  local f
+  f=$(create_ini)
+  FLEXINI_TEST_VAR="mid"
+  printf 'path = pre-${FLEXINI_TEST_VAR}-post/$FLEXINI_TEST_VAR\n' >"$f"
+
+  expand_values_on_load=true
+  flex_ini_load "$f"
+
+  [ "$(flex_ini_get path)" = "pre-mid-post/mid" ]
+}
+
+@test "expand_values_on_load leaves undefined variables empty and bare dollars literal" {
+  local f
+  f=$(create_ini)
+  unset FLEXINI_UNDEFINED_VAR
+  printf 'gone = [$FLEXINI_UNDEFINED_VAR]\nprice = 100$ each\n' >"$f"
+
+  expand_values_on_load=true
+  flex_ini_load "$f"
+
+  [ "$(flex_ini_get gone)" = "[]" ]
+  [ "$(flex_ini_get price)" = '100$ each' ]
+}
+
+@test "expand_values_on_load never executes command substitution" {
+  local f
+  f=$(create_ini)
+  local canary="$BATS_TEST_TMPDIR/expand_pwned"
+  # A command substitution planted in a value must be treated as literal
+  # text, not run, even with expansion enabled.
+  printf 'cmd = x$(touch %s)x\ntick = `touch %s`\nnested = ${FLEXINI_TEST_VAR:-$(touch %s)}\n' \
+    "$canary" "$canary" "$canary" >"$f"
+
+  expand_values_on_load=true
+  flex_ini_load "$f"
+
+  [ ! -e "$canary" ]
+  [ "$(flex_ini_get cmd)" = 'x$(touch '"$canary"')x' ]
+  [ "$(flex_ini_get tick)" = '`touch '"$canary"'`' ]
 }
 
 @test "load auto-creates a missing file when auto_create_ini_on_load is true" {


### PR DESCRIPTION
## Summary

Removes a command-injection sink (CWE-78 / CWE-95) in the optional `expand_values_on_load` feature.

Previously, when `expand_values_on_load=true`, values were expanded with:

```sh
eval "value=\"$value\""
```

That `eval` executes **any** command substitution present in a loaded value. On an untrusted ini file it is a remote-code-execution sink — a value like `x$(id > /tmp/pwned)x` runs on load.

This PR keeps the feature (and its documented contract — variable references get expanded) but makes the implementation safe:

- New `private_flex_ini_expand_value` helper expands only `$VAR` / `${VAR}` references using **plain bash indirect parameter expansion** (`${!name}`).
- **No `eval`, no command substitution.** `$(...)` and backticks are left as literal text and can never execute. Undefined variables expand to empty, matching normal shell semantics.
- Only referenced variable *names* are ever substituted; the value's own characters are never re-parsed by the shell.

FlexIni remains a fully generic library — no coupling to any consumer.

## Tests

All 78 bats tests pass; shellcheck clean. Added coverage in `tests/load.bats`:

- braced `${VAR}` and embedded-in-text expansion
- undefined var → empty, bare `$` stays literal
- **security regression:** asserts a command-substitution payload (`x$(touch …)x`, backticks, `${VAR:-$(...)}`) does **not** execute even with expansion enabled.

## Docs

`README.md` and `AGENTS.md` updated to describe the eval-free behavior; `AGENTS.md` now explicitly warns against reintroducing the `eval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)